### PR TITLE
CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+.cache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.1)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+project(
+  aff3ct-frs
+  LANGUAGES CXX
+  DESCRIPTION "Folded Reed-Solomon codes with AFF3CT"
+  VERSION 0.0.0.1)
+# enable_testing()
+
+set(CMAKE_THREAD_PREFER_PTHREAD ON)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+find_package(AFF3CT 3.0.2 REQUIRED)
+
+add_library(aff3ct-frs SHARED Decoder_FRS.cpp)
+target_link_libraries(aff3ct-frs PUBLIC aff3ct::aff3ct-static-lib)
+
+add_executable(aff3ct-frs-run main.cpp Folding.cpp)
+target_link_libraries(aff3ct-frs-run PUBLIC aff3ct-frs)
+# add_test(NAME frs-run COMMAND aff3ct-frs-run)

--- a/Decoder_FRS.cpp
+++ b/Decoder_FRS.cpp
@@ -1,6 +1,5 @@
 #include <string>
 #include <algorithm>
-#include <windows.h>
 #include "Tools/Exception/exception.hpp"
 #include "Decoder_FRS.hpp"
 

--- a/Folding.cpp
+++ b/Folding.cpp
@@ -1,5 +1,4 @@
 #include <cstdlib>
-#include <thimble/all.h>
 
 #include <iostream>
 #include <memory>

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,4 @@
 #include <cstdlib>
-#include <thimble/all.h>
 
 #include <iostream>
 #include <memory>


### PR DESCRIPTION
Добавлена возможность сборки с помощью кроссплатформенной системы CMake. При этом требуется, чтобы библиотеки AFF3CT (статическая) и pthreads были установлены на уровне системы.

Проверено на системах:
* [ ] Linux (GCC)
  * [x] Ubuntu 22.04 (g++ 11.4.0)
  * [ ] Более новые версии (g++ 12, g++ 13)
* [ ] Windows (MSVC)